### PR TITLE
Fix pair empty key check

### DIFF
--- a/vsharp/src/sem.c
+++ b/vsharp/src/sem.c
@@ -77,6 +77,10 @@ static Type infer_array(Node *n)
 }
 static Type infer_pair(Node *n)
 {
+    if(n->v.pair.key[0] == '\0') {
+        fprintf(stderr, "chave vazia em par\n");
+        error_cnt++;
+    }
     Type v = infer_expr(n->v.pair.value);
     if(v==T_INVALID){
         fprintf(stderr,"Erro semântico em par \"%s\"\n",n->v.pair.key);


### PR DESCRIPTION
## Summary
- enforce non-empty keys for pair nodes in semantic analysis

## Testing
- `make test` *(fails: bison missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849dbdd1d0c83229b8244abd7f7c95a