### PR TITLE
Resolve minor docs and add real error examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/*
 !.vscode/tasks.json
 !.vscode/launch.json
+vsharp/$f.tmp

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ WACC final: 0.091667
 ```
 vsharp/
 ├─ Makefile             # build cross-plataforma (GCC + Flex/Bison)
-├─ README.md            # este documento
+├─ README.md            # (na raiz deste repositório)
 ├─ examples/
 │  ├─ error/            # exemplos de scripts que devem dar erro
 │  └─ ok_sanity.vs      # teste mínimo (operações matemáticas e funções nativas) 

--- a/checklist
+++ b/checklist
@@ -7,7 +7,7 @@ vsharp-lexer-parser/
 ├─ examples/              → scripts de teste (.vs)
 │  ├─ sanity.vs           → cobre aritmética, arrays, print, while
 │  └─ full.vs             → cobre quase toda a EBNF (hoje falha em holders)
-├─ build/                 → artefactos (criados pelo make)
+├─ build/                 → artefatos (criados pelo make)
 └─ src/
    ├─ vsharp.l            → *lexer* 100 % da EBNF (tokens, datas, “:” etc.)
    ├─ vsharp.y            → *parser* ★ falta suporte completo a:

--- a/vsharp/$f.tmp
+++ b/vsharp/$f.tmp
@@ -1,2 +1,0 @@
-IR gerado em build/out.ll
-Executando JIT com LLVM…

--- a/vsharp/examples/error/err_lex_unknown.vs
+++ b/vsharp/examples/error/err_lex_unknown.vs
@@ -1,1 +1,2 @@
-== (erro esperado
+var x = 10;
+@

--- a/vsharp/examples/error/err_parse_missing_semi.vs
+++ b/vsharp/examples/error/err_parse_missing_semi.vs
@@ -1,1 +1,2 @@
-== (erro esperado
+var x = 1
+print(x);

--- a/vsharp/examples/error/err_sem_precision_loss.vs
+++ b/vsharp/examples/error/err_sem_precision_loss.vs
@@ -1,1 +1,2 @@
-== (erro esperado
+var i = 5;
+i = 2.5;

--- a/vsharp/examples/error/err_sem_undeclared.vs
+++ b/vsharp/examples/error/err_sem_undeclared.vs
@@ -1,1 +1,1 @@
-== (erro esperado
+print(y);

--- a/vsharp/examples/error/err_sem_wacc_arity.vs
+++ b/vsharp/examples/error/err_sem_wacc_arity.vs
@@ -1,1 +1,1 @@
-== (erro esperado
+var res = wacc(1, 2, 3);


### PR DESCRIPTION
## Summary
- ignore temp file `vsharp/$f.tmp`
- correct Portuguese spelling in `checklist`
- fix directory tree in README
- provide real failing examples under `examples/error`

## Testing
- `make test` *(fails: bison missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849e0b499888322937598b4366f1d8b